### PR TITLE
Issue #76: Fix that allows to use extended models of KeywordModel 

### DIFF
--- a/Sdl.Web.Tridion/Mapping/DefaultModelBuilder.cs
+++ b/Sdl.Web.Tridion/Mapping/DefaultModelBuilder.cs
@@ -620,10 +620,8 @@ namespace Sdl.Web.Tridion.Mapping
                 KeywordModel result;
                 if (keywordModelData.SchemaId == null)
                 {
-                    result = new KeywordModel
-                    {
-                        ExtensionData = keywordModelData.ExtensionData
-                    };
+                    result = (KeywordModel)targetType.CreateInstance();
+                    result.ExtensionData = keywordModelData.ExtensionData;
                 }
                 else
                 {


### PR DESCRIPTION
Fix that allows to use extended models of KeywordModel without the need of associating a meatadata schema to the keyword in the cms. 

Full explanation: https://tridion.stackexchange.com/questions/20292/does-dxa-support-extended-keyword-models

**Ideally I would like this issue and fix to be treated as a potential _hotfix_**